### PR TITLE
[angular] critters 0.0.19 => 0.0.20

### DIFF
--- a/src/angularjs/package-lock.json
+++ b/src/angularjs/package-lock.json
@@ -97,7 +97,7 @@
         "cacache": "17.1.3",
         "chokidar": "3.5.3",
         "copy-webpack-plugin": "11.0.0",
-        "critters": "0.0.19",
+        "critters": "0.0.20",
         "css-loader": "6.8.1",
         "esbuild-wasm": "0.17.19",
         "fast-glob": "3.2.12",
@@ -5520,9 +5520,9 @@
       }
     },
     "node_modules/critters": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.19.tgz",
-      "integrity": "sha512-Fm4ZAXsG0VzWy1U30rP4qxbaWGSsqXDgSupJW1OUJGDAs0KWC+j37v7p5a2kZ9BPJvhRzWm3be+Hc9WvQOBUOw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.20.tgz",
+      "integrity": "sha512-CImNRorKOl5d8TWcnAz5n5izQ6HFsvz29k327/ELy6UFcmbiZNOsinaKvzv16WZR0P6etfSWYzE47C4/56B3Uw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",


### PR DESCRIPTION
given this [report](https://github.com/Pixailz/ft_transcendence/security/dependabot/25), critters sould be bump to `0.0.20` because `0.0.17-0.0.19` suffer from an issue when parsing the HTML which leads to a potential [cross-site scripting (XSS)](https://owasp.org/www-community/attacks/xss/) bug.