### PR TITLE
[front:guard] patch infinite loop when first login

### DIFF
--- a/src/angularjs/src/app/services/auth-guard.service.ts
+++ b/src/angularjs/src/app/services/auth-guard.service.ts
@@ -46,7 +46,7 @@ export class AuthGuardService implements CanActivate {
 			console.log("[angular:AuthGuardService] bad token");
 			return false;
 		}
-		if (state.url !== "/register")
+		if (state.url.indexOf('/register') === -1)
 			return await this.canActivateRegister(returnUrl);
 		return true;
 	}


### PR DESCRIPTION
the loop would be caused by an invalid explicit check of `state.url` but without taking in account that query parameters would be added
