### PR TITLE
patch ball launch direction

### DIFF
--- a/src/nestjs/src/websocket/game/game.service.ts
+++ b/src/nestjs/src/websocket/game/game.service.ts
@@ -740,7 +740,7 @@ export class WSGameService {
 	}
 
 	private async resetBall(server: Server, room: LobbyI) {
-		const futurevx = room.state.ball.vx > 0 ? -1 : 1;
+		const futurevx = room.state.ball.x > 800 ? -1 : 1;
 		room.state.ball.vx = 0;
 		room.state.ball.vy = 0;
 		room.state.ball.x = 400;


### PR DESCRIPTION
ball should be launched in direction of the winner, which is not the case due to a typo